### PR TITLE
Use JSON input format - use message queue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,16 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 #      dependencies
 #    - yum autoremove
 #    - remove yum caches
-RUN yum update -y --setopt=tsflags=nodocs \
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    yum update -y --setopt=tsflags=nodocs \
     && \
     yum install -y --setopt=tsflags=nodocs \
         ruby \
     && \
     mkdir -p ${HOME} \
+    && \
+    yum install -y --setopt=tsflags=nodocs \
+        python-qpid-proton \
     && \
     yum install -y --setopt=tsflags=nodocs --setopt=history_record=yes \
         gcc-c++ \
@@ -52,7 +56,9 @@ RUN yum update -y --setopt=tsflags=nodocs \
 COPY fluent.conf /etc/fluent/fluent.conf
 RUN  mkdir /etc/fluent/config.d
 COPY config.d/*.conf /etc/fluent/config.d/
+COPY simple_recv.py /opt/app-root/bin/
 
 WORKDIR ${HOME}
 CMD ["fluentd"]
+#CMD ["fluentd", "-vv"]
 

--- a/config.d/00-base.conf
+++ b/config.d/00-base.conf
@@ -1,3 +1,3 @@
 <system>
-  log_level debug
+  log_level warn
 </system>

--- a/config.d/01-system.conf
+++ b/config.d/01-system.conf
@@ -1,13 +1,12 @@
 <source>
-  @type tail
+  @type exec
   @label @SYSTEM
-  path /var/log/messages*
-  pos_file /var/log/node.log.pos
-  tag system.var.log
-  format multiline
-  format_firstline /^[A-Z][a-z]{2} [ |0-3]+[0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] /
-  format1 /^(?<time>[^ ]* [^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\: *(?<message>.*)$/
-  read_from_head true
+  command '/opt/app-root/bin/simple_recv.py -a bitscout-qpid-router:5672/bitscout -m 0'
+  format json
+  tag bitscout
+#  time_key @timestamp
+#  time_format %FT%T
+#  time_format %FT%T.%NZ
 </source>
 
 <label @SYSTEM>
@@ -15,17 +14,15 @@
     type record_transformer
     enable_ruby
     <record>
-      hostname ${host}
-      version 1.0.6
+      time #{@timestamp}
     </record>
-    remove_keys host
   </filter>
   <match **>
     @type elasticsearch_dynamic
     host "#{ENV['ES_HOST'] || 'localhost'}"
     port "#{ENV['ES_PORT'] || 9200}"
     scheme "#{ENV['ES_CA'] ? 'https' : 'http'}"
-    index_name syslog.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+    index_name bitscout.${Time.at(time).getutc.strftime(@logstash_dateformat)}
     user fluentd
     password changeme
 
@@ -38,3 +35,10 @@
     disable_retry_limit
   </match>
 </label>
+
+# <label @SYSTEM>
+#   <match **>
+#       @type stdout
+#       output_type json
+#   </match>
+# </label>

--- a/simple_recv.py
+++ b/simple_recv.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import print_function
+import optparse
+from proton.handlers import MessagingHandler
+from proton.reactor import Container
+import sys
+
+class Recv(MessagingHandler):
+    def __init__(self, url, count):
+        super(Recv, self).__init__()
+        self.url = url
+        self.expected = count
+        self.received = 0
+
+    def on_start(self, event):
+#        sys.stderr.write("simple_recv.py connecting to url %s expected %d\n" % (self.url, self.expected))
+        event.container.create_receiver(self.url)
+
+    def on_message(self, event):
+        if event.message.id and event.message.id < self.received:
+            # ignore duplicate message
+            return
+        if self.expected == 0 or self.received < self.expected:
+#            sys.stderr.write("simple_recv.py received message [%s]\n" % str(event.message.body))
+            print(event.message.body)
+            sys.stdout.flush()
+            self.received += 1
+            if self.received == self.expected:
+                event.receiver.close()
+                event.connection.close()
+
+parser = optparse.OptionParser(usage="usage: %prog [options]")
+parser.add_option("-a", "--address", default="localhost:5672/examples",
+                  help="address from which messages are received (default %default)")
+parser.add_option("-m", "--messages", type="int", default=100,
+                  help="number of messages to receive; 0 receives indefinitely (default %default)")
+opts, args = parser.parse_args()
+
+try:
+    Container(Recv(opts.address, opts.messages)).run()
+except KeyboardInterrupt: pass
+
+
+


### PR DESCRIPTION
Receive input in JSON format for elasticsearch output plugin
For the time being, use the python qpid proton simple_recv.py
script with a fluentd in_exec plugin to receive the JSON
formatted messages from the message queue.
