### PR TITLE
Expose monitor_agent port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:centos7
 MAINTAINER The ViaQ Community <community@TBA>
 
 EXPOSE 10514
+EXPOSE 24220
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
@@ -52,6 +53,10 @@ VOLUME /data
 
 RUN  mkdir -p /etc/fluent/config.d
 COPY amqp_qpid/ ${HOME}/amqp_qpid/
+
+# Uncomment to install Multiprocess Input Plugin
+# see http://docs.fluentd.org/articles/in_multiprocess
+# RUN  fluent-gem install fluent-plugin-multiprocess
 
 WORKDIR ${HOME}
 ADD run.sh /usr/sbin/


### PR DESCRIPTION
I would like to expose port that is used by `monitor_agent`. I use `monitor_agent` in my pbench testing branch in [integration-tests](https://github.com/ViaQ/integration-tests/tree/pbench-test) and I need to have this port exposed in docker-fluentd Dockerfile.

Also we can consider adding `monitor_agent` to master branch of docker-fluentd (this means adding [the following configuration part](https://github.com/ViaQ/integration-tests/blob/pbench-test/openshift-fluentd.conf#L7-L11)) then exposing the port in Dockerfile would not seem confusing. But I am not sure if this can introduce any security concerns. WDYT @richm ?
