### PR TITLE
make it easy to run and test fluentd with simple configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:centos7
 MAINTAINER The ViaQ Community <community@TBA>
 
 EXPOSE 10514
-EXPOSE 24220
+EXPOSE 24224
 
 ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
@@ -10,6 +10,7 @@ ENV HOME=/opt/app-root/src \
     FLUENTD_VERSION=0.12.26 \
     GEM_HOME=/opt/app-root/src \
     SYSLOG_LISTEN_PORT=10514 \
+    FLUENTD_FORWARD_INPUT_PORT=24224 \
     RUBYLIB=/opt/app-root/src/amqp_qpid/lib
 
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
@@ -51,7 +52,10 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 
 VOLUME /data
 
-RUN  mkdir -p /etc/fluent/config.d
+RUN  mkdir -p /etc/fluent/configs.d ${HOME}/forwarder-example
+COPY data/ ${HOME}/forwarder-example/
+COPY fluent.conf /etc/fluent/
+COPY configs.d/ /etc/fluent/configs.d/
 COPY amqp_qpid/ ${HOME}/amqp_qpid/
 
 # Uncomment to install Multiprocess Input Plugin
@@ -59,7 +63,5 @@ COPY amqp_qpid/ ${HOME}/amqp_qpid/
 # RUN  fluent-gem install fluent-plugin-multiprocess
 
 WORKDIR ${HOME}
-ADD run.sh /usr/sbin/
-CMD /usr/sbin/run.sh
-
-
+ADD run.sh ${HOME}/
+CMD ${HOME}/run.sh

--- a/README.md
+++ b/README.md
@@ -1,17 +1,68 @@
 # docker-fluentd [![Build Status](https://travis-ci.org/ViaQ/docker-fluentd.svg?branch=master)](https://travis-ci.org/ViaQ/docker-fluentd)
-ViaQ Fluentd docker container - implements the aggregator/formatter
+ViaQ Fluentd docker container - can be used as either a local collector, or as an aggregator/formatter/normalizer, for feeding data into Elasticsearch.
 
 ## Environmental variables:
-`ES_HOST` must be FQDN of ElasticSearch server.  
-`ES_PORT` must be the port on which the ElasticSearch server is listening.  
-`SYSLOG_LISTEN_PORT` the port this rsyslog instance is listening for. both TCP and UDP.  
+Elasticsearch output
+* `ENABLE_ES` - use Elasticsearch for output.  Defaults to `true`
+* `LOGSTASH_PREFIX` - Elasticsearch index name prefix.  Defaults to `viaq`
+* `ES_HOST` must be FQDN of ElasticSearch server.  Defaults to `viaq-elasticsearch`.
+* `ES_PORT` must be the port on which the ElasticSearch server is listening.  Defaults to `9200`.
+
+Syslog input
+* `ENABLE_SYSLOG` - use syslog (RFC5424) listener for tcp/udp input.  Defaults to `true`.
+* `SYSLOG_LISTEN_PORT` the port this rsyslog instance is listening for. both TCP and UDP.  Defaults to `10514`.
+* `SYSLOG_LISTEN_BIND_ADDR` - ip address to bind to.  Defaults to `0.0.0.0`
+* `FLUENTD_SYSLOG_LOG_LEVEL` - default is `FLUENTD_LOG_LEVEL` or `warn`
+
+Forwarder input
+* `ENABLE_FORWARD` - use fluentd forwarder listener (e.g. for fluent-cat) for tcp/udp input.  Defaults to `true`.
+* `FLUENTD_FORWARD_INPUT_PORT` - default is `24224`
+* `FLUENTD_FORWARD_INPUT_BIND_ADDR` - default is `0.0.0.0`
+* `FLUENTD_FORWARD_INPUT_LOG_LEVEL` - default is `FLUENTD_LOG_LEVEL` or `warn`
+
+Journal input
+* `ENABLE_JOURNAL` - read from systemd journal - default `false`
+* `JOURNAL_DIR` - default is `/run/log`
+* `FLUENTD_JOURNAL_LOG_LEVEL` - default is `FLUENTD_LOG_LEVEL` or `warn`
+
+Tail/file input
+* `ENABLE_TAIL` - default is `false`
+* `FLUENTD_TAIL_LOG_DIR` - default `/var/log` - reads the file(s) `messages*` in that dir
+* `FLUENTD_TAIL_LOG_LEVEL` - default is `FLUENTD_LOG_LEVEL` or `warn`
+
+AMQP input
+* `ENABLE_AMQP_INPUT` - read from AMQP queue - default `true`
+* `FLUENTD_AMQP_INPUT_URL` - default is `amqp://viaq-qpid-router:5672/viaq`
+* `FLUENTD_AMQP_INPUT_LOG_LEVEL` - default is `FLUENTD_LOG_LEVEL` or `warn`
+
+Stdout output (for debugging)
+* `ENABLE_STDOUT` - default `false`
+
+If you want to use fluentd with or as a normalizer, you must define the following:
+
+* `NORMALIZER_NAME` - The string name of the normalize reported in the ES record as `"pipeline_metadata":{"normalizer":{"name": "NORMALIZER_NAME"}}`.  This is a descriptive string used for searching and filtering.
+* `NORMALIZER_IP` - not currently used
+* `NORMALIZER_HOSTNAME` - hostname of the normalizer node/machine.  This is reported in the ES record as `"pipeline_metadata":{"normalizer":{"hostname": "NORMALIZER_HOSTNAME"}}`.
 
 ## External Fluentd config
-In order to add own Fluentd configuration file please add the configuration files to a local directory and map in to `/data` docker volume.  
-The following files are taken form the local directory:  
-`fluent.conf, config.d/*, patterns.d/*`  
+In order to add own Fluentd configuration file please add the configuration files to a local directory and map in to `/data` docker volume.
+The following files are taken form the local directory:
+`fluent.conf, config.d/*, patterns.d/*`
 In case `fluent.conf` exists, the default `config.d/*.conf` is removed and not used in the container.
 
-## Running:
-docker run -d -p $syslog_listen_port:$syslog_listen_port/tcp -p $syslog_listen_port:$syslog_listen_port/udp -v $local_dir:/data -u $uid -e ES_HOST=$elasticsearchhost -e ES_PORT=$port -e SYSLOG_LISTEN_PORT=$syslog_listen_port -e NORMALIZER_NAME=container-rsyslog8.17 -e NORMALIZER_IP=$normalizer_ip -e LOGSTASH_PREFIX=v2016.03.10.0-viaq --name $appname $image
 
+## Running:
+
+Using plain docker, default arguments::
+
+    # docker run -d -p 10514:10514/udp -p 24224:24224/udp \
+      -e FLUENTD_LOG_LEVEL=info --name viaq-fluentd viaq/fluentd
+
+Using specified syslog listen host, fluentd config dir, normalizer configuration::
+
+    # docker run -d -p $syslog_listen_port:$syslog_listen_port/tcp \
+      -p $syslog_listen_port:$syslog_listen_port/udp -v $local_dir:/data \
+      -u $uid -e ES_HOST=$elasticsearchhost -e ES_PORT=$port \
+      -e SYSLOG_LISTEN_PORT=$syslog_listen_port \
+      -e NORMALIZER_NAME=container-rsyslog8.17 -e NORMALIZER_IP=$normalizer_ip \
+      -e LOGSTASH_PREFIX=v2016.03.10.0-viaq --name viaq-fluentd viaq/docker-fluentd

--- a/configs.d/filter/timestamp.conf
+++ b/configs.d/filter/timestamp.conf
@@ -1,0 +1,7 @@
+<filter **>
+  type record_transformer
+  enable_ruby
+  <record>
+    time #{@timestamp}
+  </record>
+</filter>

--- a/configs.d/input/amqp.conf
+++ b/configs.d/input/amqp.conf
@@ -1,0 +1,7 @@
+<source>
+  @type amqp_qpid
+  url "#{ENV['FLUENTD_AMQP_INPUT_URL'] || 'amqp://viaq-qpid-router:5672/viaq'}"
+  tag viaq.amqp
+  format json
+  log_level "#{ENV['FLUENTD_AMQP_INPUT_LOG_LEVEL'] || ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</source>

--- a/configs.d/input/forward.conf
+++ b/configs.d/input/forward.conf
@@ -1,0 +1,6 @@
+<source>
+  @type forward
+  port "#{ENV['FLUENTD_FORWARD_INPUT_PORT'] || '24224'}"
+  bind "#{ENV['FLUENTD_FORWARD_INPUT_BIND_ADDR'] || '0.0.0.0'}"
+  log_level "#{ENV['FLUENTD_FORWARD_INPUT_LOG_LEVEL'] || ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</source>

--- a/configs.d/input/journal.conf
+++ b/configs.d/input/journal.conf
@@ -1,0 +1,8 @@
+<source>
+  @type systemd
+  path "#{ENV['JOURNAL_DIR'] || '/run/log'}/journal"
+  pos_file "#{ENV['JOURNAL_DIR'] || '/run/log'}/journal.pos"
+  tag system.journal
+  read_from_head true
+  log_level "#{ENV['FLUENTD_JOURNAL_LOG_LEVEL'] || ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</source>

--- a/configs.d/input/syslog.conf
+++ b/configs.d/input/syslog.conf
@@ -1,0 +1,7 @@
+<source>
+  type syslog
+  port #{ENV['SYSLOG_LISTEN_PORT'] || 10514}
+  bind "#{ENV['SYSLOG_LISTEN_BIND_ADDR'] || '0.0.0.0'}"
+  tag syslog
+  log_level "#{ENV['FLUENTD_SYSLOG_LOG_LEVEL'] || ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</source>

--- a/configs.d/input/var-log-messages.conf
+++ b/configs.d/input/var-log-messages.conf
@@ -1,0 +1,16 @@
+<source>
+  @type tail
+  path "#{ENV['FLUENTD_TAIL_LOG_DIR'] || '/var/log'}/messages*"
+  pos_file "#{ENV['FLUENTD_TAIL_LOG_DIR'] || '/var/log'}/system.pos"
+  tag system.*
+  format multiline
+  # Begin possible multiline match: "Mmm DD HH:MM:SS "
+  format_firstline /^[A-Z][a-z]{2}\s+[0-3]?[0-9]\s+[0-2][0-9]:[0-5][0-9]:[0-6][0-9]\s/
+  # extract metadata from same line that matched format_firstline
+  format1 /^(?<time>\S+\s+\S+\s+\S+)\s+(?<host>\S+)\s+(?<ident>[\w\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?[^\:]*\:\s*(?<message>.*)$/
+  time_format %b %d %H:%M:%S
+  read_from_head true
+  keep_time_key true
+  multiline_flush_interval 1s
+  log_level "#{ENV['FLUENTD_TAIL_LOG_LEVEL'] || ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</source>

--- a/configs.d/output/elasticsearch.conf
+++ b/configs.d/output/elasticsearch.conf
@@ -1,0 +1,17 @@
+<match **>
+  @type elasticsearch_dynamic
+  host "#{ENV['ES_HOST'] || 'localhost'}"
+  port "#{ENV['ES_PORT'] || 9200}"
+  scheme "#{(ENV['ES_CA'] || ENV['ES_CLIENT_CERT']) ? 'https' : 'http'}"
+  index_name viaq.${Time.at(time).getutc.strftime(@logstash_dateformat)}
+  user fluentd
+  password changeme
+
+  client_key "#{ENV['ES_CLIENT_KEY']}"
+  client_cert "#{ENV['ES_CLIENT_CERT']}"
+  ca_file "#{ENV['ES_CA']}"
+
+  flush_interval 1s
+  max_retry_wait 300
+  disable_retry_limit
+</match>

--- a/configs.d/output/stdout.conf
+++ b/configs.d/output/stdout.conf
@@ -1,0 +1,4 @@
+<match ** >
+  @type stdout
+  @id stdout_output
+</match>

--- a/fluent.conf
+++ b/fluent.conf
@@ -1,0 +1,9 @@
+<system>
+  log_level "#{ENV['FLUENTD_LOG_LEVEL'] || 'warn'}"
+</system>
+
+@include configs.d/input/*.conf
+
+@include configs.d/filter/*.conf
+
+@include configs.d/output/*.conf

--- a/run.sh
+++ b/run.sh
@@ -1,40 +1,87 @@
 #!/bin/sh
 
-set -e
-set -x
+set -euxo pipefail
 
-ES_HOST=${ES_HOST:-viaq-elasticsearch}
-ES_PORT=${ES_PORT:-9200}
-SYSLOG_LISTEN_PORT=${SYSLOG_LISTEN_PORT:-4000}
-DEBUG_FLUENTD=${DEBUG_FLUENTD:-false}
-LOGSTASH_PREFIX=${LOGSTASH_PREFIX:-v2016.03.10.0-viaq}
+# Elasticsearch plugin params
+export ENABLE_ES=${ENABLE_ES:-true}
+export ES_HOST=${ES_HOST:-viaq-elasticsearch}
+export ES_PORT=${ES_PORT:-9200}
+export LOGSTASH_PREFIX=${LOGSTASH_PREFIX:-viaq}
+# other params available for ES output plugin
+# ES_CA - CA cert file
+# ES_CLIENT_CERT - client cert file
+# ES_CLIENT_KEY - cilent key file
+export ENABLE_SYSLOG=${ENABLE_SYSLOG:-true}
+export SYSLOG_LISTEN_PORT=${SYSLOG_LISTEN_PORT:-10514}
+# other params available for syslog input plugin
+# SYSLOG_LISTEN_BIND_ADDR - ip address to bind to - default 0.0.0.0
+# FLUENTD_SYSLOG_LOG_LEVEL - default is FLUENTD_LOG_LEVEL or warn
+export ENABLE_FORWARD=${ENABLE_FORWARD:-true}
+# other params available for forward input plugin
+# FLUENTD_FORWARD_INPUT_PORT - default is 24224
+# FLUENTD_FORWARD_INPUT_BIND_ADDR - default is 0.0.0.0
+# FLUENTD_FORWARD_INPUT_LOG_LEVEL - default is FLUENTD_LOG_LEVEL or warn
+export ENABLE_JOURNAL=${ENABLE_JOURNAL:-false}
+# other params available for journal plugin
+# JOURNAL_DIR - default is /run/log
+# FLUENTD_JOURNAL_LOG_LEVEL - default is FLUENTD_LOG_LEVEL or warn
+export ENABLE_TAIL=${ENABLE_TAIL:-false}
+# other params available for tail input plugin
+# FLUENTD_TAIL_LOG_DIR - default /var/log - reads messages*
+# FLUENTD_TAIL_LOG_LEVEL - default is FLUENTD_LOG_LEVEL or warn
+export ENABLE_AMQP_INPUT=${ENABLE_AMQP_INPUT:-true}
+# other params available for amqp input plugin
+# FLUENTD_AMQP_INPUT_URL - default is amqp://viaq-qpid-router:5672/viaq
+# FLUENTD_AMQP_INPUT_LOG_LEVEL - default is FLUENTD_LOG_LEVEL or warn
+export ENABLE_STDOUT=${ENABLE_STDOUT:-false}
+
+export FLUENTD_LOG_LEVEL=${FLUENTD_LOG_LEVEL:-warn}
+export DEBUG_FLUENTD=${DEBUG_FLUENTD:-false}
+export NORMALIZER_NAME=${NORMALIZER_NAME:-}
+export NORMALIZER_IP=${NORMALIZER_IP:-}
+export NORMALIZER_HOSTNAME=${NORMALIZER_HOSTNAME:-}
+
 
 if [ "$DEBUG_FLUENTD" = true ]; then
     FLUENTD_ARGS="-vv"
+    FLUENTD_LOG_LEVEL=trace
 else
     FLUENTD_ARGS=""
 fi
 
-if [ -f "/data/fluent.conf" ]; then
+if [ -f /data/fluent.conf ]; then
     cp /data/fluent.conf /etc/fluent/fluent.conf
-    if [ -d "/data/config.d" ]; then
-        rm /etc/fluent/config.d/*.conf || true
+    if [ -d /data/config.d ]; then
+        rm -rf /etc/fluent/config.d
         cp -R /data/config.d /etc/fluent/
     fi
-    if [ -d "/data/patterns.d" ]; then
+    if [ -d /data/patterns.d ]; then
         cp -R /data/patterns.d /etc/fluent/
     fi
+else
+    set -- $ENABLE_SYSLOG /etc/fluent/configs.d/input/syslog.conf \
+        $ENABLE_FORWARD /etc/fluent/configs.d/input/forward.conf \
+        $ENABLE_JOURNAL /etc/fluent/configs.d/input/journal.conf \
+        $ENABLE_TAIL /etc/fluent/configs.d/input/var-log-messages.conf \
+        $ENABLE_AMQP_INPUT /etc/fluent/configs.d/input/amqp.conf \
+        $ENABLE_ES /etc/fluent/configs.d/output/elasticsearch.conf \
+        $ENABLE_STDOUT /etc/fluent/configs.d/output/stdout.conf
+    while [ -n "${1:-}" ] ; do
+        t_or_f=$1 ; shift ; fn=$1
+        if ! $t_or_f && test -f $fn ; then
+            cp /dev/null $fn # disable this feature
+        fi
+        shift
+    done
 fi
 
-for file in /etc/fluent/fluent.conf /etc/fluent/config.d/*.conf /etc/fluent/config.d/**/*.conf ; do
-    if [ ! -f "$file" ] ; then continue ; fi
-    sed -i -e "s/%ES_HOST%/$ES_HOST/g" -e "s/%ES_PORT%/$ES_PORT/g" \
-        -e "s/%SYSLOG_LISTEN_PORT%/$SYSLOG_LISTEN_PORT/g" \
-        -e "s/%LOGSTASH_PREFIX%/$LOGSTASH_PREFIX/g" \
-        -e "s/%NORMALIZER_NAME%/$NORMALIZER_NAME/g" -e "s/%NORMALIZER_IP%/$NORMALIZER_IP/g" \
-        -e "s/%NORMALIZER_HOSTNAME%/$NORMALIZER_HOSTNAME/g" \
-        "$file"
-done
+find /etc/fluent -name \*.conf -exec sed -i \
+     -e "s/%ES_HOST%/$ES_HOST/g" -e "s/%ES_PORT%/$ES_PORT/g" \
+     -e "s/%SYSLOG_LISTEN_PORT%/$SYSLOG_LISTEN_PORT/g" \
+     -e "s/%LOGSTASH_PREFIX%/$LOGSTASH_PREFIX/g" \
+     -e "s/%NORMALIZER_NAME%/$NORMALIZER_NAME/g" \
+     -e "s/%NORMALIZER_IP%/$NORMALIZER_IP/g" \
+     -e "s/%NORMALIZER_HOSTNAME%/$NORMALIZER_HOSTNAME/g" \
+     {} \;
 
 fluentd ${FLUENTD_ARGS}
-


### PR DESCRIPTION
I added simple configs for input from syslog, forwarder (fluent-cat),
systemd journal, /var/log/messages*, and AMQP, a simple filter, and
simple configs for elasticsearch and stdout output.  Each of these
can be enabled or disabled by an environment variable::

  docker run ... -e ENABLE_XXX=[true|false]

By default ENABLE_ES, ENABLE_SYSLOG, ENABLE_FORWARD, ENABLE_AMQP are
true, and ENABLE_JOURNAL, ENABLE_TAIL, ENABLE_STDOUT are false.
See README.md for more information.
