### PR TITLE
Use monitor_agent in Travis scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ services:
   - docker
 
 before_install:
-- docker build -t viaq/fluentd-latest .
+- sudo apt-get install -y curl
+- sudo apt-get install -y jq
+- docker build -t viaq/fluentd .
 - docker images 
 - docker ps -a
-- docker create viaq/fluentd-latest
-- docker ps -a
-- docker start `docker ps -aq`
+- docker run -d -p 5141:5141/udp -p 24224:24224/udp -p 24220:24220 -e FLUENTD_LOG_LEVEL=info --name viaq-fluentd viaq/fluentd
 - docker ps -a
 
 script: ./travis_scripts/basic_test.sh

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In case `fluent.conf` exists, the default `config.d/*.conf` is removed and not u
 
 Using plain docker, default arguments::
 
-    # docker run -d -p 10514:10514/udp -p 24224:24224/udp \
+    # docker run -d -p 10514:10514/udp -p 24224:24224/udp -p 24220:24220 \
       -e FLUENTD_LOG_LEVEL=info --name viaq-fluentd viaq/fluentd
 
 Using specified syslog listen host, fluentd config dir, normalizer configuration::

--- a/travis_scripts/basic_test.sh
+++ b/travis_scripts/basic_test.sh
@@ -5,7 +5,7 @@
 set -ev
 
 # Give the container some room to start up
-sleep 10
+sleep 5 
 docker ps -a
 
 CONTAINER_ID=$(docker ps -aq)
@@ -16,3 +16,5 @@ if [ "$STATUS" == "false" ]; then
   docker logs $CONTAINER_ID
   exit 2
 fi
+
+curl localhost:24220/api/plugins.json | jq


### PR DESCRIPTION
Enable monitoring agent (see http://docs.fluentd.org/articles/monitoring).

During Travis job we install and use [jq](https://stedolan.github.io/jq/) library that enables us to get and pretty print JSON output from fluentd monitoring REST END point (see [this example](https://travis-ci.org/ViaQ/docker-fluentd/builds/136423702#L959)). Note jq library also has very rich JSON [filtering capabilities](https://stedolan.github.io/jq/manual/) which can enable us to implement various tests/check on CLI in the future.
