### PR TITLE
Do not generate gem documentation. Image build speedup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         fluent-plugin-systemd systemd-journal \
         fluent-plugin-parser \
         fluent-plugin-grok-parser \
-        rspec simplecov \
+        rspec simplecov  --no-document \
     && \
     yum -y history undo last \
     && \


### PR DESCRIPTION
Just skip documentation generation when installing gems. This shortens docker image build.
