### PR TITLE
Switch to Ruby 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,13 +47,17 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         fluent-plugin-systemd systemd-journal \
         fluent-plugin-parser \
         fluent-plugin-grok-parser \
-        rspec simplecov \
+        rspec simplecov  --no-document \
     && \
     yum -y history undo last \
     && \
     yum -y autoremove \
     && \
     yum clean all
+
+# Install Ruby 2.2
+RUN yum -y install centos-release-scl && \
+    yum -y install rh-ruby22 
 
 VOLUME /data
 

--- a/run.sh
+++ b/run.sh
@@ -94,4 +94,7 @@ find /etc/fluent -name \*.conf -exec sed -i \
      -e "s/%NORMALIZER_HOSTNAME%/$NORMALIZER_HOSTNAME/g" \
      {} \;
 
+# Switch to Ruby 2.2
+scl enable rh-ruby22 bash
+
 fluentd ${FLUENTD_ARGS}


### PR DESCRIPTION
@richm PTAL
This is my take on switching to Ruby 2.2 (for perf tests). ATM I just want you to have a look and comment if you think things could be done better.
Actually, I do not know how to verify the fluentd is really running on Ruby 2.2. I checked the container logs and it seems that the command `scl enable rh-ruby22 bash` just before starting fluentd (in `run.sh`) went without any errors/warnings, so I think it should be used... but if you know how we can double-check please feel free to comment.
