### PR TITLE
set RUBY_SCL_VER=rh-ruby22 to use ruby 2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ ENV HOME=/opt/app-root/src \
     FLUENTD_VERSION=0.12.26 \
     GEM_HOME=/opt/app-root/src \
     SYSLOG_LISTEN_PORT=10514 \
-    RUBYLIB=/opt/app-root/src/amqp_qpid/lib
+    RUBYLIB=/opt/app-root/src/amqp_qpid/lib \
+    RUBYVERREPOPKGS="centos-release-scl" \
+    RUBYVERPKGS="rh-ruby22 scl-utils"
+
+# use docker ... -e RUBY_SCL_VER=rh-ruby22 to use ruby 2.2
 
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
@@ -30,13 +34,13 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 #      dependencies
 #    - yum autoremove
 #    - remove yum caches
-RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm ${RUBYVERREPOPKGS} && \
     yum update -y --setopt=tsflags=nodocs \
     && \
     mkdir -p ${HOME}/amqp_qpid \
     && \
     yum install -y --setopt=tsflags=nodocs \
-        ruby rubygem-qpid_proton \
+        ruby rubygem-qpid_proton ${RUBYVERPKGS} \
     && \
     yum install -y --setopt=tsflags=nodocs --setopt=history_record=yes \
         gcc-c++ ruby-devel libcurl-devel make cmake swig \
@@ -47,7 +51,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
         fluent-plugin-systemd systemd-journal \
         fluent-plugin-parser \
         fluent-plugin-grok-parser \
-        rspec simplecov \
+        rspec simplecov --no-document \
     && \
     yum -y history undo last \
     && \

--- a/run.sh
+++ b/run.sh
@@ -94,4 +94,9 @@ find /etc/fluent -name \*.conf -exec sed -i \
      -e "s/%NORMALIZER_HOSTNAME%/$NORMALIZER_HOSTNAME/g" \
      {} \;
 
+# Switch to Ruby 2.2
+if [ -n "${RUBY_SCL_VER:-}" ] ; then
+    scl enable $RUBY_SCL_VER bash
+fi
+
 fluentd ${FLUENTD_ARGS}


### PR DESCRIPTION
@lukas-vlcek Try this instead - it will keep using the current version of ruby, but allow us at runtime to use ruby 2.2 like this::

```
# docker run -d -e RUBY_SCL_VER=rh-ruby22 viaq/fluentd
2f02ef20ef98a080273....
# docker logs 2f02ef20ef98a080273....
...
+ '[' -n rh-ruby22 ']'
+ scl enable rh-ruby22 bash
+ fluentd
```
